### PR TITLE
Add separator between links to referenced slides

### DIFF
--- a/components/BiblioList.vue
+++ b/components/BiblioList.vue
@@ -63,8 +63,8 @@ citation_state.init().then( (cite) =>
           <span class="biblio_id" v-if="showid">[{{elm.id}}] </span>
           <span class="biblio_fullref">{{elm.full_bib}}</span>
           <span class="biblio_pageref" v-if="elm.pages?.length" >
-            (<template v-for="page in elm.pages">
-               <Link :to="page" >{{page}}</Link>
+            (<template v-for="(page, index) in elm.pages">
+               <template v-if="index != 0">,&nbsp;</template><Link :to="page" >{{page}}</Link>
              </template>)
           </span>
        </li>


### PR DESCRIPTION
This adds a separator between links to slides that reference the respective bibliography entry.

Previously, if multiple slides referenced the same entry, links would not be visible as different links.

E.g., if slides 1, 2, and 3 reference an entry, this would print the following:

```text
[1] Author, "Title", Year. (123)
```

Now, links are separated by a comma with a non-breaking-space in-between:

```text
[1] Author, "Title", Year. (1, 2, 3)
```