### PR TITLE
Hide pages indicator if only one page exists

### DIFF
--- a/components/BiblioList.vue
+++ b/components/BiblioList.vue
@@ -68,7 +68,7 @@ citation_state.init().then( (cite) =>
              </template>)
           </span>
        </li>
-       <p>page  {{index+1}} / {{biblio.length}} </p>
+       <p v-if="biblio.length > 1">page  {{index+1}} / {{biblio.length}} </p>
      </ul>
      </template>
      <!-- hack to have correct number of click -->


### PR DESCRIPTION
If all references fit on one page, the page indicator should not be shown imo.

Alternatively, this could be made configurable in case this should still show "page 1/1".