### PR TITLE
Fix typo in bibliography layout

### DIFF
--- a/layouts/biblio.vue
+++ b/layouts/biblio.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 <template>
 	<div class="slidev-layout biblio">
            <slot>
-	   <h1 class="text-center" >Biblography</h1>
+	   <h1 class="text-center" >Bibliography</h1>
 	   </slot>
 	   <BiblioList />
 	</div>


### PR DESCRIPTION
This fixes a small typo in the "Bibliography" heading.